### PR TITLE
Change menu item text.

### DIFF
--- a/clang-format/Info.plist
+++ b/clang-format/Info.plist
@@ -34,7 +34,7 @@
 					<key>XCSourceEditorCommandIdentifier</key>
 					<string>$(PRODUCT_BUNDLE_IDENTIFIER).ClangFormatCommand</string>
 					<key>XCSourceEditorCommandName</key>
-					<string>Format Source Code</string>
+					<string>Format Selected Source Code</string>
 				</dict>
 			</array>
 			<key>XCSourceEditorExtensionPrincipalClass</key>


### PR DESCRIPTION
Change menu item text from "Format Source Code" to "Format Selected Source Code", in order to be less ambiguous.