### PR TITLE
Use LLVM as a base for loading a custom style to mimic CLI clang-format's behavior

### DIFF
--- a/clang-format/ClangFormatCommand.mm
+++ b/clang-format/ClangFormatCommand.mm
@@ -142,6 +142,7 @@ NSString* kFormatFileCommandIdentifier = [NSString stringWithFormat:@"%@.FormatF
             // parse style
             llvm::StringRef configString(reinterpret_cast<const char*>(config.bytes),
                                          config.length);
+            clang::format::getPredefinedStyle("LLVM", language, &format);
             auto error = clang::format::parseConfiguration(configString, &format);
             if (error) {
                 completionHandler([NSError


### PR DESCRIPTION
It looks like clang-format loads the LLVM style as a base before applying the custom `.clang-format` file to it. So far, we've started with the empty (`NoStyle`). This breaks with `.clang-format` files that do not contain a `BasedOnStyle` rule, e.g. the one [the Blender project uses](https://github.com/blender/blender/blob/master/.clang-format) if the same file is used with the CLI version of `clang-format`. 

Fixes https://github.com/mapbox/XcodeClangFormat/issues/44 reported by @anktkr.