### PR TITLE
Fix conditional on C headers

### DIFF
--- a/clang-format/ClangFormatCommand.mm
+++ b/clang-format/ClangFormatCommand.mm
@@ -26,7 +26,8 @@ clang::format::FormatStyle::LanguageKind getLanguageKind(XCSourceTextBuffer* buf
                 return clang::format::FormatStyle::LK_ObjC;
             }
         }
-    } else if (UTTypeEqual(uti, kUTTypeCPlusPlusHeader) || UTTypeEqual(uti, kUTTypeCPlusPlusSource) ||
+    }
+    if (UTTypeEqual(uti, kUTTypeCPlusPlusHeader) || UTTypeEqual(uti, kUTTypeCPlusPlusSource) ||
                UTTypeEqual(uti, kUTTypeCHeader) || UTTypeEqual(uti, kUTTypeCSource)) {
         return clang::format::FormatStyle::LK_Cpp;
     } else if (UTTypeEqual(uti, kUTTypeObjectiveCSource) ||


### PR DESCRIPTION
I had trouble formatting header files, I believe this one `else` was misplaced, and removing it fixes the language kind detection.